### PR TITLE
RavenDB-24205 - Orleans - Make database creation optional in RavenDbMembershipTable

### DIFF
--- a/.github/workflows/orleansTests.yml
+++ b/.github/workflows/orleansTests.yml
@@ -3,11 +3,11 @@ name: tests/orleans
 on:
   push:
     branches:
-        - main
+        - master
 
   pull_request:
     branches:
-        - main
+        - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/Orleans.Providers.RavenDB/Configuration/RavenDbOptions.cs
+++ b/src/Orleans.Providers.RavenDB/Configuration/RavenDbOptions.cs
@@ -32,5 +32,11 @@ namespace Orleans.Providers.RavenDb.Configuration
         /// Whether to wait for index updates after saving changes to ensure query consistency.
         /// </summary>
         public bool WaitForIndexesAfterSaveChanges { get; set; }
+
+        /// <summary>
+        /// Determines whether the provider should automatically create the database
+        /// if it does not already exist. 
+        /// </summary>
+        public bool EnsureDatabaseExists { get; set; } = true;
     }
 }

--- a/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
+++ b/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
@@ -42,10 +42,13 @@ public class RavenDbMembershipTable : IMembershipTable
             };
             _documentStore.Initialize();
 
-            // Ensure the database exists
-            var dbExists = _documentStore.Maintenance.Server.Send(new GetDatabaseRecordOperation(_options.DatabaseName)) != null;
-            if (dbExists == false)
-                _documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(_options.DatabaseName)));
+            if (_options.EnsureDatabaseExists)
+            {
+                // Ensure the database exists
+                var dbExists = _documentStore.Maintenance.Server.Send(new GetDatabaseRecordOperation(_options.DatabaseName)) != null;
+                if (dbExists == false)
+                    _documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(_options.DatabaseName)));
+            }
 
             var indexes = _documentStore.Maintenance.Send(new GetIndexNamesOperation(0, int.MaxValue));
             if (indexes.Contains(nameof(MembershipByClusterIdAliveTimeStatusAndPort)) == false)

--- a/tests/UnitTests/RavenDbMembershipTableOptionsTests.cs
+++ b/tests/UnitTests/RavenDbMembershipTableOptionsTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Providers.RavenDb.Configuration;
+using Orleans.Providers.RavenDb.Membership;
+using UnitTests.Infrastructure;
+using Xunit;
+
+namespace UnitTests
+{
+    public class RavenDbMembershipTableOptionsTests
+    {
+        [Fact]
+        public async Task Should_Not_Create_Database_When_EnsureDatabaseExists_Is_False()
+        {
+            var membershipOptions = new RavenDbMembershipOptions
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                DatabaseName = "ShouldNotExist",
+                EnsureDatabaseExists = false
+            };
+
+            var membershipTable = new RavenDbMembershipTable(membershipOptions, NullLogger<RavenDbMembershipTable>.Instance);
+
+            var exception = await Assert.ThrowsAsync<OrleansException> (async () =>
+            {
+                await membershipTable.InitializeMembershipTable(true);
+            });
+            Assert.Contains("Database 'ShouldNotExist' does not exist", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link:
https://issues.hibernatingrhinos.com/issue/RavenDB-24205/Orleans-Make-database-creation-optional-in-RavenDbMembershipTable

### Additional info
Added EnsureDatabaseExists option to allow skipping automatic database creation. Includes test for validation.
