### PR TITLE
RavenDB-24220 - Orleans - Support multiple Orleans ServiceIds in a single database

### DIFF
--- a/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
+++ b/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
@@ -9,5 +9,13 @@
         /// The unique identifier of the Orleans cluster. This is used to scope membership data in RavenDB.
         /// </summary>
         public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Optional identifier used to support multiple Orleans ServiceIds within the same database.
+        /// When set, this value will be included in document IDs and used to scope all membership data. 
+        /// This allows multiple Orleans applications (clusters with different ServiceIds) to share a single database.
+        /// If not set, the provider will assume a single-ServiceId-per-database model (default behavior).
+        /// </summary>
+        public string? ServiceId { get; set; }
     }
 }

--- a/src/Orleans.Providers.RavenDB/Membership/MembershipEntryDocument.cs
+++ b/src/Orleans.Providers.RavenDB/Membership/MembershipEntryDocument.cs
@@ -56,6 +56,10 @@
         /// </summary>
         public List<SuspectTime> SuspectTimes { get; set; }
 
+        /// <summary>
+        /// Identifies the ServiceId this membership entry belongs to. Used to support multiple ServiceIds in the same database.
+        /// </summary>
+        public string ServiceId { get; set; }
     }
 
     /// <summary>
@@ -73,6 +77,11 @@
         /// The current global version of the membership table.
         /// </summary>
         public int Version { get; set; }
+
+        /// <summary>
+        /// Identifies the ServiceId this table version belongs to. Used to isolate versioning across multiple ServiceIds.
+        /// </summary>
+        public string ServiceId { get; set; }
 
     }
 

--- a/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
+++ b/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
@@ -185,7 +185,8 @@ public class RavenDbMembershipTable : IMembershipTable
             };
 
             // Ensure the provided TableVersion is greater than the stored version
-            if (tableVersion.Version <= versionDoc.Version)
+            if (versionDoc.Version > 0 &&
+                tableVersion.Version <= versionDoc.Version)
             {
                 _logger.LogWarning("InsertRow failed due to outdated version. Provided={Provided}, Current={Current}",
                     tableVersion.Version, versionDoc.Version);

--- a/tests/UnitTests/RavenDbMembershipTableOptionsTests.cs
+++ b/tests/UnitTests/RavenDbMembershipTableOptionsTests.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Providers.RavenDb.Configuration;
 using Orleans.Providers.RavenDb.Membership;
+using Raven.Client.Documents;
 using UnitTests.Infrastructure;
 using Xunit;
 
@@ -25,6 +27,66 @@ namespace UnitTests
                 await membershipTable.InitializeMembershipTable(true);
             });
             Assert.Contains("Database 'ShouldNotExist' does not exist", exception.Message);
+        }
+
+        [Fact]
+        public async Task CanStoreMembershipEntriesForMultipleServiceIdsInSameDatabase()
+        {
+            using var documentStore = new DocumentStore
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                Database = Guid.NewGuid().ToString()
+            };
+            documentStore.Initialize();
+
+            var options1 = new RavenDbMembershipOptions
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                ServiceId = "Service-A",
+                DatabaseName = documentStore.Database,
+                ClusterId = "19804f4c-9af4-493e-b40a-d441bd10eacd"
+            };
+
+            var options2 = new RavenDbMembershipOptions
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                ServiceId = "Service-B",
+                DatabaseName = documentStore.Database,
+                ClusterId = "19804f4c-9af4-493e-b40a-d441bd10eacd",
+                EnsureDatabaseExists = false // use the same database without creating a new one
+            };
+
+            var membership1 = new RavenDbMembershipTable(options1, NullLogger<RavenDbMembershipTable>.Instance);
+            var membership2 = new RavenDbMembershipTable(options2, NullLogger<RavenDbMembershipTable>.Instance);
+
+            await membership1.InitializeMembershipTable(true);
+            await membership2.InitializeMembershipTable(true);
+
+            var siloEntry1 = new MembershipEntry
+            {
+                SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 0),
+                HostName = "NodeA"
+            };
+
+            var siloEntry2 = new MembershipEntry
+            {
+                SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 2222), 0),
+                HostName = "NodeB"
+            };
+
+            var tableVersion = new TableVersion(0, "init");
+
+            await membership1.InsertRow(siloEntry1, tableVersion);
+            await membership2.InsertRow(siloEntry2, tableVersion);
+
+            using (var session = documentStore.OpenAsyncSession())
+            {
+                var versionDocs = await session.Query<TableVersionDocument>().ToListAsync();
+                Assert.Equal(2, versionDocs.Count);
+
+                var membershipDocs = await session.Query<MembershipEntryDocument>().ToListAsync();
+                Assert.Equal(2, membershipDocs.Count);
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-24220/Orleans-Support-multiple-Orleans-ServiceIds-in-a-single-database

This change updates the membership document ID format to include both `ServiceId` and `ClusterId` (unless they are equal, to maintain backward compatibility).
Also adjusts the relevant queries to ensure correctness.