### PR TITLE
RavenDB-24197 - Orleans - Support injecting custom IDocumentStore in UseRavenDbMembershipTable

### DIFF
--- a/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
+++ b/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Orleans.Providers.RavenDb.Configuration
+﻿using Raven.Client.Documents;
+
+namespace Orleans.Providers.RavenDb.Configuration
 {
     /// <summary>
     /// Configuration options for RavenDB-based Orleans membership.
@@ -9,5 +11,10 @@
         /// The unique identifier of the Orleans cluster. This is used to scope membership data in RavenDB.
         /// </summary>
         public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Allows injecting a custom RavenDB document store. If set, the internal creation will be skipped.
+        /// </summary>
+        public IDocumentStore? DocumentStore { get; set; }
     }
 }

--- a/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
+++ b/src/Orleans.Providers.RavenDB/Configuration/RavenDbMembershipOptions.cs
@@ -1,6 +1,4 @@
-﻿using Raven.Client.Documents;
-
-namespace Orleans.Providers.RavenDb.Configuration
+﻿namespace Orleans.Providers.RavenDb.Configuration
 {
     /// <summary>
     /// Configuration options for RavenDB-based Orleans membership.
@@ -11,10 +9,5 @@ namespace Orleans.Providers.RavenDb.Configuration
         /// The unique identifier of the Orleans cluster. This is used to scope membership data in RavenDB.
         /// </summary>
         public string ClusterId { get; set; }
-
-        /// <summary>
-        /// Allows injecting a custom RavenDB document store. If set, the internal creation will be skipped.
-        /// </summary>
-        public IDocumentStore? DocumentStore { get; set; }
     }
 }

--- a/src/Orleans.Providers.RavenDB/Configuration/RavenDbOptions.cs
+++ b/src/Orleans.Providers.RavenDB/Configuration/RavenDbOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Cryptography.X509Certificates;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 
 namespace Orleans.Providers.RavenDb.Configuration
@@ -38,5 +39,10 @@ namespace Orleans.Providers.RavenDb.Configuration
         /// if it does not already exist. 
         /// </summary>
         public bool EnsureDatabaseExists { get; set; } = true;
+
+        /// <summary>
+        /// Allows injecting a custom RavenDB document store. If set, the internal creation will be skipped.
+        /// </summary>
+        public IDocumentStore? DocumentStore { get; set; }
     }
 }

--- a/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
+++ b/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTable.cs
@@ -33,6 +33,13 @@ public class RavenDbMembershipTable : IMembershipTable
     {
         try
         {
+            if (_options.DocumentStore != null)
+            {
+                _documentStore = _options.DocumentStore;
+                _logger.LogInformation("Using externally provided DocumentStore.");
+                return;
+            }
+
             _documentStore = new DocumentStore
             {
                 Database = _options.DatabaseName,

--- a/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTableExtensions.cs
+++ b/src/Orleans.Providers.RavenDB/Membership/RavenDbMembershipTableExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Orleans.Providers.RavenDb.Configuration;
+using Raven.Client.Documents;
 
 namespace Orleans.Providers.RavenDb.Membership;
 
@@ -20,6 +21,29 @@ public static class RavenDbMembershipTableExtensions
         {
             var options = new RavenDbMembershipOptions();
             configureOptions(options);
+            services.AddSingleton(options);
+            services.AddSingleton<IMembershipTable, RavenDbMembershipTable>();
+        });
+    }
+
+    /// <summary>
+    /// Configures RavenDB as the membership table provider for the Orleans silo using an existing DocumentStore.
+    /// </summary>
+    /// <param name="builder">The Orleans silo builder.</param>
+    /// <param name="documentStore">An existing initialized RavenDB <see cref="IDocumentStore"/> to be used by the membership provider.</param>
+    /// <param name="configureOptions">An action to configure <see cref="RavenDbMembershipOptions"/>.</param>
+    /// <returns>The updated <see cref="ISiloBuilder"/> instance.</returns>
+    public static ISiloBuilder UseRavenDbMembershipTable(this ISiloBuilder builder, IDocumentStore documentStore, Action<RavenDbMembershipOptions>? configureOptions = null)
+    {
+        return builder.ConfigureServices(services =>
+        {
+            var options = new RavenDbMembershipOptions
+            {
+                DocumentStore = documentStore
+            };
+
+            configureOptions?.Invoke(options);
+
             services.AddSingleton(options);
             services.AddSingleton<IMembershipTable, RavenDbMembershipTable>();
         });

--- a/src/Orleans.Providers.RavenDB/StorageProviders/RavenDbGrainStorageExtensions.cs
+++ b/src/Orleans.Providers.RavenDB/StorageProviders/RavenDbGrainStorageExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers.RavenDb.Configuration;
 using Orleans.Storage;
+using Raven.Client.Documents;
 
 namespace Orleans.Providers.RavenDb.StorageProviders;
 
@@ -81,5 +82,29 @@ public static class RavenDbGrainStorageExtensions
         services.AddSingleton(s => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredKeyedService<IGrainStorage>(name));
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds RavenDB grain storage to the silo with a named provider and a custom <see cref="IDocumentStore"/>.
+    /// </summary>
+    /// <param name="builder">The Orleans silo builder.</param>
+    /// <param name="name">The name of the storage provider.</param>
+    /// <param name="documentStore">The custom <see cref="IDocumentStore"/> to use.</param>
+    /// <param name="configureOptions">A delegate to further configure <see cref="RavenDbGrainStorageOptions"/>.</param>
+    /// <returns>The updated <see cref="ISiloBuilder"/>.</returns>
+    public static ISiloBuilder AddRavenDbGrainStorage(
+        this ISiloBuilder builder,
+        string name,
+        IDocumentStore documentStore,
+        Action<RavenDbGrainStorageOptions>? configureOptions = null)
+    {
+        return builder.ConfigureServices(services =>
+        {
+            services.AddRavenDbGrainStorage(name, options =>
+            {
+                options.DocumentStore = documentStore;
+                configureOptions?.Invoke(options);
+            });
+        }); ;
     }
 }

--- a/tests/UnitTests/RavenDbConfigurationTests.cs
+++ b/tests/UnitTests/RavenDbConfigurationTests.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Orleans.Providers.RavenDb.Configuration;
+using Orleans.Providers.RavenDb.Membership;
+using Orleans.Providers.RavenDb.StorageProviders;
+using Raven.Client.Documents;
+using UnitTests.Infrastructure;
+using Xunit;
+
+namespace UnitTests
+{
+    public class RavenDbConfigurationTests
+    {
+        [Fact]
+        public void CanInjectCustomDocumentStoreIntoMembershipOptions()
+        {
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                Database = "TestDb"
+            };
+            documentStore.Initialize();
+
+            var builder = new HostBuilder()
+                .UseOrleans(silo =>
+                {
+                    silo.UseRavenDbMembershipTable(documentStore);
+                });
+
+            using var host = builder.Build();
+            var options = host.Services.GetRequiredService<RavenDbMembershipOptions>();
+
+            Assert.Equal(documentStore, options.DocumentStore);
+        }
+
+        [Fact]
+        public void CanInjectCustomDocumentStoreIntoGrainStorageOptions()
+        {
+            var documentStore = new DocumentStore
+            {
+                Urls = new[] { RavenDbFixture.ServerUrl.AbsoluteUri },
+                Database = "TestDb"
+            };
+            documentStore.Initialize();
+
+            var providerName = "MyCustomGrainStorage";
+
+            var builder = new HostBuilder()
+                .UseOrleans(silo =>
+                {
+                    silo.AddRavenDbGrainStorage(providerName, documentStore);
+                });
+
+            using var host = builder.Build();
+
+            var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<RavenDbGrainStorageOptions>>();
+            var options = optionsMonitor.Get(providerName);
+
+            Assert.Equal(documentStore, options.DocumentStore);
+        }
+    }
+    }


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-24197/Orleans-Support-injecting-custom-IDocumentStore-in-UseRavenDbMembershipTable

This adds an overload to `UseRavenDbMembershipTable` that accepts an existing `IDocumentStore`.