### PR TITLE
RavenDB-25776: Upgrade Orleans submodule to 9.2.1 + align provider/tests/samples

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,55 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Aspire.Seq" Version="13.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.CodeGenerator" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.Cosmos" Version="9.2.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
+
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="13.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Seq" Version="13.0.0" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.RavenDB" Version="13.0.0" />
+
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Blazor.Serialization" Version="8.0.0" />
+    <PackageVersion Include="Blazor.LocalStorage" Version="8.0.0" />
+    <PackageVersion Include="Bogus" Version="35.5.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
+    <PackageVersion Include="MudBlazor" Version="6.17.0" />
+
+    <PackageVersion Include="Spectre.Console" Version="0.48.0" />
+    <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.48.0" />
+
+    <PackageVersion Include="RavenDB.Client" Version="6.2.0" />
+    <PackageVersion Include="RavenDB.Embedded" Version="7.0.0" />
+
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+
+    <PackageVersion Include="OrleansDashboard" Version="8.2.0" />
+  </ItemGroup>
+</Project>

--- a/samples/Chirper/Chirper.Client/Chirper.Client.csproj
+++ b/samples/Chirper/Chirper.Client/Chirper.Client.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
-    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.ImageSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Chirper/Chirper.Grains.Interfaces/Chirper.Grains.Interfaces.csproj
+++ b/samples/Chirper/Chirper.Grains.Interfaces/Chirper.Grains.Interfaces.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
   </ItemGroup>
 
 </Project>

--- a/samples/Chirper/Chirper.Grains.Interfaces/Models/ChirperMessage.cs
+++ b/samples/Chirper/Chirper.Grains.Interfaces/Models/ChirperMessage.cs
@@ -8,21 +8,22 @@ public record class ChirperMessage(
     /// <summary>
     /// The message content for this chirp message entry.
     /// </summary>
-    string Message,
+    [property: Id(0)] string Message,
 
     /// <summary>
     /// The timestamp of when this chirp message entry was originally republished.
     /// </summary>
-    DateTimeOffset Timestamp,
+    [property: Id(1)] DateTimeOffset Timestamp,
 
     /// <summary>
     /// The user name of the publisher of this chirp message.
     /// </summary>
-    string PublisherUserName)
+    [property: Id(2)] string PublisherUserName)
 {
     /// <summary>
     /// The unique id of this chirp message.
     /// </summary>
+    [Id(3)]
     public Guid MessageId { get; } = Guid.NewGuid();
 
     /// <summary>

--- a/samples/Chirper/Chirper.Grains/Chirper.Grains.csproj
+++ b/samples/Chirper/Chirper.Grains/Chirper.Grains.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Chirper/Chirper.Server/Chirper.Server.csproj
+++ b/samples/Chirper/Chirper.Server/Chirper.Server.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="9.1.2" />
-    <PackageReference Include="OrleansDashboard" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
+    <PackageReference Include="OrleansDashboard" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Platform/Platform.ApiService/Platform.ApiService.csproj
+++ b/samples/Platform/Platform.ApiService/Platform.ApiService.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Seq" Version="9.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="9.1.2" />
-	  <PackageReference Include="Serilog" Version="4.3.0" />
-	  <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
+    <PackageReference Include="Aspire.Seq" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Orleans.Client" />
+	  <PackageReference Include="Serilog" />
+	  <PackageReference Include="Serilog.Sinks.Seq" />
   </ItemGroup>
 
 </Project>

--- a/samples/Platform/Platform.AppHost/Platform.AppHost.csproj
+++ b/samples/Platform/Platform.AppHost/Platform.AppHost.csproj
@@ -16,9 +16,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.0" />
-		<PackageReference Include="Aspire.Hosting.Orleans" Version="13.0.0" />
-		<PackageReference Include="Aspire.Hosting.Seq" Version="13.0.0" />
-		<PackageReference Include="CommunityToolkit.Aspire.Hosting.RavenDB" Version="13.0.0" />
+		<PackageReference Include="Aspire.Hosting.AppHost" />
+		<PackageReference Include="Aspire.Hosting.Orleans" />
+		<PackageReference Include="Aspire.Hosting.Seq" />
+		<PackageReference Include="CommunityToolkit.Aspire.Hosting.RavenDB" />
 	</ItemGroup>
 </Project>

--- a/samples/Platform/Platform.Contracts/Platform.Contracts.csproj
+++ b/samples/Platform/Platform.Contracts/Platform.Contracts.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/samples/Platform/Platform.ServiceDefaults/Platform.ServiceDefaults.csproj
+++ b/samples/Platform/Platform.ServiceDefaults/Platform.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
 </Project>

--- a/samples/Platform/Platform.Silo/Platform.Silo.csproj
+++ b/samples/Platform/Platform.Silo/Platform.Silo.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Seq" Version="13.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="9.1.2" />
+    <PackageReference Include="Aspire.Seq" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Platform/Platform.Web/Platform.Web.csproj
+++ b/samples/Platform/Platform.Web/Platform.Web.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Seq" Version="13.0.0" />
+    <PackageReference Include="Aspire.Seq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ShoppingCart/Abstractions/Orleans.ShoppingCart.Abstractions.csproj
+++ b/samples/ShoppingCart/Abstractions/Orleans.ShoppingCart.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.*" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
   </ItemGroup>
 
 </Project>

--- a/samples/ShoppingCart/Grains/InventoryGrain.cs
+++ b/samples/ShoppingCart/Grains/InventoryGrain.cs
@@ -53,5 +53,6 @@ public sealed class InventoryGrain(
 [GenerateSerializer]
 public class InventoryState
 {
+    [Id(0)]
     public HashSet<string> Items { get; set; } = new HashSet<string>();
 }

--- a/samples/ShoppingCart/Grains/Orleans.ShoppingCart.Grains.csproj
+++ b/samples/ShoppingCart/Grains/Orleans.ShoppingCart.Grains.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.*" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.*" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ShoppingCart/Silo/Orleans.ShoppingCart.Silo.csproj
+++ b/samples/ShoppingCart/Silo/Orleans.ShoppingCart.Silo.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Blazor.Serialization" Version="8.0.0" />
-    <PackageReference Include="Blazor.LocalStorage" Version="8.0.0" />
-    <PackageReference Include="Bogus" Version="35.5.0" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="8.*" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="8.*" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="9.*" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="MudBlazor" Version="6.17.0" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Blazor.Serialization" />
+    <PackageReference Include="Blazor.LocalStorage" />
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="MudBlazor" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Resources;
 
 [assembly: AssemblyCopyright("© Hibernating Rhinos 2009 - 2025 All rights reserved.")]
 
-[assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6")]
-[assembly: AssemblyInformationalVersion("1.0.6-175f97f")]
+[assembly: AssemblyVersion("1.0.7")]
+[assembly: AssemblyFileVersion("1.0.7")]
+[assembly: AssemblyInformationalVersion("1.0.7-8331fd9")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageIconUrl>http://static.ravendb.net/logo-for-nuget.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/ravendb/Orleans.Providers.RavenDB</PackageProjectUrl>

--- a/src/Orleans.Providers.RavenDB/Orleans.Providers.RavenDB.csproj
+++ b/src/Orleans.Providers.RavenDB/Orleans.Providers.RavenDB.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="RavenDB.Client" Version="6.2.0" />
-		<PackageReference Include="Microsoft.Orleans.Reminders" Version="9.1.2" />
-		<PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" PrivateAssets="all" />
+		<PackageReference Include="RavenDB.Client" />
+		<PackageReference Include="Microsoft.Orleans.Reminders" />
+		<PackageReference Include="Microsoft.Orleans.Sdk" PrivateAssets="all" />
 	</ItemGroup>
 
 </Project>

--- a/src/Orleans.Providers.RavenDB/StorageProviders/RavenDbGrainStorage.cs
+++ b/src/Orleans.Providers.RavenDB/StorageProviders/RavenDbGrainStorage.cs
@@ -145,6 +145,7 @@ namespace Orleans.Providers.RavenDb.StorageProviders
 
                 grainState.RecordExists = false;
                 grainState.ETag = null;
+                grainState.State = Activator.CreateInstance<T>();
             }
             catch (Exception ex)
             {

--- a/tests/UnitTests/Infrastructure/RavenDbGrainPersistenceTestsRunner.cs
+++ b/tests/UnitTests/Infrastructure/RavenDbGrainPersistenceTestsRunner.cs
@@ -1,0 +1,13 @@
+using TestExtensions.Runners;
+using UnitTests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace UnitTests.Infrastructure;
+
+internal sealed class RavenDbGrainPersistenceTestsRunner : GrainPersistenceTestsRunner
+{
+    public RavenDbGrainPersistenceTestsRunner(ITestOutputHelper output, RavenDbStorageFixture fixture, string grainNamespace = "UnitTests.Grains")
+        : base(output, fixture, grainNamespace)
+    {
+    }
+}

--- a/tests/UnitTests/RavenDBPersistenceGrainTests.cs
+++ b/tests/UnitTests/RavenDBPersistenceGrainTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests
         {
             fixture.EnsurePreconditionsMet();
 
-            _runner = new GrainPersistenceTestsRunner(output, fixture, grainNamespace);
+            _runner = new RavenDbGrainPersistenceTestsRunner(output, fixture, grainNamespace);
         }
 
 

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -8,19 +8,19 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="Microsoft.Orleans.Server" Version="9.1.2" />
-		<PackageReference Include="RavenDB.Embedded" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="9.1.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Microsoft.Orleans.Server" />
+		<PackageReference Include="RavenDB.Embedded" />
+		<PackageReference Include="Microsoft.Orleans.CodeGenerator">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.console">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-25776/Orleans-Upgrade-submodule-to-v9.2.1-and-adapt-provider-tests

Upgrad `libs/orleans` submodule to v9.2.1 and align all Orleans package references across the repo.

Changes:

- Enable Central Package Management (`Directory.Packages.props`) and remove per-csproj version pins.
- Provider: after `ClearStateAsync`(delete), also reset in-memory `grainState.State` to a default instance to match Orleans 9.2.1 delete/clear expectations.
- Tests: update persistence harness (new concrete `RavenDbGrainPersistenceTestsRunner`).
- Samples: fix Orleans serialization IDs 